### PR TITLE
Use raw strings to silence deprecation warnings

### DIFF
--- a/ensemblrest/ensemblrest.py
+++ b/ensemblrest/ensemblrest.py
@@ -150,7 +150,7 @@ class EnsemblRest(object):
         """Check for mandatory parameters"""
         
         #Verify required variables and raise an Exception if needed
-        mandatory_params = re.findall('\{\{(?P<m>[a-zA-Z1-9_]+)\}\}', func['url'])
+        mandatory_params = re.findall(r'\{\{(?P<m>[a-zA-Z1-9_]+)\}\}', func['url'])
         
         for param in mandatory_params:
             if param not in kwargs:
@@ -170,7 +170,7 @@ class EnsemblRest(object):
         mandatory_params = self.__check_params(func, kwargs)
         
         # resolving urls
-        url = re.sub('\{\{(?P<m>[a-zA-Z1-9_]+)\}\}', lambda m: "%s" % kwargs.get(m.group(1)),
+        url = re.sub(r'\{\{(?P<m>[a-zA-Z1-9_]+)\}\}', lambda m: "%s" % kwargs.get(m.group(1)),
                      self.session.base_url + func['url'])
         
         # debug


### PR DESCRIPTION
Beginning with Python 3.6, using a backslash literal before a character
(where the two do *not* form an escape sequence) has been deprecated.
It's unclear if the author means for there to be two characters - a
backslash and then the following character (e.g. `'\-'`) or a single
character (e.g. a newline literal `'\n'`

https://docs.python.org/dev/whatsnew/3.6.html#deprecated-python-behavior

------------------------------------------------------------------------

To silence these deprecation warnings, use a raw string syntax instead.

Note that these strings are exactly equivalent:

    $ PYTHONWARNINGS=always python3
    >>> old_pattern = '\{\{(?P<m>[a-zA-Z1-9_]+)\}\}'
    <stdin>:1: DeprecationWarning: invalid escape sequence \{
    >>> new_pattern = r'\{\{(?P<m>[a-zA-Z1-9_]+)\}\}'
    >>> new_pattern == old_pattern
    True