### PR TITLE
Add automatic release notes generation and auto-publish

### DIFF
--- a/.github/workflows/push_tag.yaml
+++ b/.github/workflows/push_tag.yaml
@@ -75,6 +75,9 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: dist/*
+          generate_release_notes: true
+          draft: false
+          prerelease: false
   publish:
     needs:
       - release


### PR DESCRIPTION
## Summary
Enhances the GitHub release creation to automatically generate release notes and publish releases immediately.

## Changes
- Added `generate_release_notes: true` to automatically generate release notes from commits and PRs
- Added `draft: false` to publish releases immediately (not as drafts)
- Added `prerelease: false` to mark releases as stable

## Benefits
- Automatic release notes include:
  - List of merged pull requests
  - New contributors
  - Full changelog link
- Releases are published immediately upon tag push
- No manual intervention needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)