### PR TITLE
ci: bump GitHub Actions to Node 24-compatible major versions

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -20,10 +20,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/push_tag.yaml
+++ b/.github/workflows/push_tag.yaml
@@ -18,14 +18,14 @@ jobs:
       discussions: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-tags: true
           ref: ${{ github.ref_name}}
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ">=3.10 <3.15"
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -65,13 +65,13 @@ jobs:
         run: poetry build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-dists
           path: dist/
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: dist/*
@@ -89,7 +89,7 @@ jobs:
       name: dev
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set Poetry Version
         id: set-poetry-version
@@ -104,7 +104,7 @@ jobs:
         run: poetry self add poetry-dynamic-versioning[plugin]
 
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-dists
           path: dist


### PR DESCRIPTION
## Summary

- Updates all actions that GitHub flagged as Node 20-deprecated in the v0.3.4 release run, ahead of the **2026-06-16** forced-upgrade date.
- All bumps are major-version bumps, but compatible with current usage:
  - \`softprops/action-gh-release@v3\` is purely a Node 20 → Node 24 runtime bump.
  - \`upload-artifact@v7\` / \`download-artifact@v8\` add opt-in features (direct uploads, hash-mismatch enforcement) but keep the default zip behavior the workflow relies on.
  - \`checkout@v6\`, \`setup-python@v6\`, \`cache@v5\` are routine major bumps with no API changes affecting our usage.
- Left \`coverallsapp/github-action@master\` alone — it wasn't in the deprecation warnings, and re-pinning that is a separate hygiene task.

## Bumps

| Action | Before | After |
|--------|--------|-------|
| \`actions/checkout\` | v4 | v6 |
| \`actions/setup-python\` | v5 | v6 |
| \`actions/cache\` | v4 | v5 |
| \`actions/upload-artifact\` | v4 | v7 |
| \`actions/download-artifact\` | v4 | v8 |
| \`softprops/action-gh-release\` | v2 | v3 |

## Test plan

- [ ] PR CI (\`pull_request.yaml\`) passes across the 3.10–3.14 matrix — exercises \`checkout\`, \`setup-python\`, \`cache\`
- [ ] On the next tag push, \`push_tag.yaml\` end-to-end succeeds — exercises the artifact actions and \`action-gh-release\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)